### PR TITLE
fix(readme): incorrect conan c++ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project uses **CMake** as its build system.
 ### Build & Run
 ```sh
 # Configure and generate build files
-conan install . --output-folder=build/ --build=missing
+conan install . --output-folder=build/ --build=missing -s compiler.cppstd=23
 cmake -B build/
 
 # Compile the project


### PR DESCRIPTION
# fix(readme): incorrect conan c++ version

## Summary
Th project require c++23, conan gives older version

## Changes
update the install cmd to req c++23

## Checklist
- [x] I have renamed the first header of the template -_-
- [x] I have tested my modifications
- [x] I have done the relevant documentation
- [x] I have set the Reviewers & Assignees
- [x] I have set the correct `Labels`
- [x] I have set the `rtype` project
- [x] I have set `Status` / `Priority` / `Size` / `Start date` / `End date`
- [x] I have set the relevant `Milestone`
