### PR TITLE
Updated `clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -89,7 +89,7 @@ BraceWrapping:
   AfterControlStatement: Never
   AfterEnum:       true
   AfterExternBlock: false
-  AfterFunction:   false
+  AfterFunction:   true
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     true


### PR DESCRIPTION
## Summary
New update on the `clang-format` file

## Changes
Added line break after `class`, `enum` and `struct` and `functions`
Changed line length `80`→ `120`
Added braces after control statement (`if`, `else` etc)
Removed empty line at start of file
Changed constructor initializer format (on the same line if possible, else each on a line)
Removed spaced between `:` when initializing container:
```
true:                                  false:
var arr = [ 1, 2, 3 ];         vs.     var arr = [1, 2, 3];
f({a : 1, b : 2, c : 3});              f({a: 1, b: 2, c: 3})
```
Fixed comment indentation 

## Checklist
- [x] I have renamed the first header of the template -_-
- [x] I have tested my modifications
- [x] I have done the relevant documentation
- [x] I have set the Reviewers & Assignees
- [x] I have set the correct `Labels`
- [x] I have set the `rtype` project
- [x] I have set `Status` / `Priority` / `Size` / `Start date` / `End date`
- [x] I have set the relevant `Milestone`
