### PR TITLE
lib(rtnt): Windows ambiguous operator declaration for vectors

### DIFF
--- a/lib/rtnt/include/rtnt/core/packet.hpp
+++ b/lib/rtnt/include/rtnt/core/packet.hpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 #if defined(_WIN32)
-#include <windows.h>
+#include <winsock2.h>
 #elif defined(__linux__)
 #include <arpa/inet.h>
 


### PR DESCRIPTION
# bug(lib>rtnt): Windows ambiguous operator declaration for vectors

## Issues closed
<!-- Write here which issues have been closed: -->
Closes #100 

## Summary
Fixed compilation on Windows

## Changes
- Moved `std::vector` `>>` & `<<` operators to global instead of members because Windows can't differentiate the two
- Fixed missing includes

## Screenshots/Video
<img width="640" height="362" alt="Untitled" src="https://github.com/user-attachments/assets/800bc5a7-8716-421f-abaf-bea3b335f9de" />

[rtnt_(tests)_2025-12-15_11-28-09..log](https://github.com/user-attachments/files/24163308/rtnt_.tests._2025-12-15_11-28-09.log)

## Checklist
- [x] I have renamed the first header of the template
- [x] I have tested my modifications
- [x] I have done the relevant documentation
- [x] I have set the Reviewers & Assignees
- [x] I have set the correct `Labels`
- [x] I have set the `rtype` project
- [x] I have set `Status` / `Priority` / `Size` / `Start date` / `End date`
- [x] I have set the relevant `Milestone`
