### PR TITLE
feat(lib/rteng): Added colors for each players

### DIFF
--- a/lib/rteng/src/rteng.cpp
+++ b/lib/rteng/src/rteng.cpp
@@ -79,8 +79,22 @@ GameEngine::GameEngine(unsigned short port)
     _server->onMessage([](SessionPtr, rtnt::core::Packet&) { LOG_INFO("Received message from cli."); });
     _server->onConnect([this](SessionPtr s) {
         LOG_INFO("Accepting new connection.");
+
+        static const std::vector<comp::MyColor> palette = {
+            {255, 0, 0, 255},    // red
+            {0, 255, 0, 255},    // green
+            {0, 0, 255, 255},    // blue
+            {255, 255, 0, 255},  // yellow
+            {255, 0, 255, 255},  // magenta
+            {0, 255, 255, 255},  // cyan
+        };
+
+        const size_t index = _clientToServer.size() % palette.size();
+        const comp::MyColor fillColor = palette[index];
+
         auto id = registerEntity<comp::IO, comp::Position, comp::Rectangle>(
-            nullptr, {}, {25, 25}, {true, 150, 150, {0, 0, 0, 255}, {255, 0, 0, 255}});
+            nullptr, {}, {25, 25}, {true, 150, 150, {0, 0, 0, 255}, fillColor});
+
         _clientToServer.emplace(s->getId(), id);
         _server->sendTo(s, createWorldInit());
     });


### PR DESCRIPTION
# feat(lib/rteng): Added colors for each players

## Summary
Subject asks for players to be differentiable

## Changes
- list of colors
- set color to players

## Breaking changes
- [ ] This code contains breaking changes:
```
```

## Screenshots/Video
<img width="1616" height="1285" alt="image" src="https://github.com/user-attachments/assets/5cc9969c-4a2a-408f-99ee-8b0213950ecc" />

## Checklist
- [x] I have renamed the first header of the template -_-
- [x] I have tested my modifications
- [x] I have done the relevant documentation
- [x] I have set the Reviewers & Assignees
- [x] I have set the correct `Labels`
- [x] I have set the `rtype` project
- [x] I have set `Status` / `Priority` / `Size` / `Start date` / `End date`
- [x] I have set the relevant `Milestone`
