### PR TITLE
fix(lib/rtecs/systems): Changed systems from unique_ptr to shared_ptr

### DIFF
--- a/lib/rtecs/include/rtecs/ECS.hpp
+++ b/lib/rtecs/include/rtecs/ECS.hpp
@@ -33,7 +33,7 @@ class ECS final
 {
 private:
     std::unordered_map<types::EntityID, types::Entity> _entities;
-    std::vector<std::unique_ptr<systems::ISystem>> _systems;
+    std::vector<std::shared_ptr<systems::ISystem>> _systems;
     size_t _entitiesID = 0;
 
     /// Key: Component hashcode - Value: Pointer to an ISparseSet
@@ -366,7 +366,7 @@ public:
      *
      * @param system A unique pointer that will be moved to the ECS.
      */
-    void registerSystem(std::unique_ptr<systems::ISystem> &&system);
+    void registerSystem(const std::shared_ptr<systems::ISystem> &system);
 
     /**
      * @brief Create a new system class from the SystemWrapper.

--- a/lib/rtecs/src/ECS.cpp
+++ b/lib/rtecs/src/ECS.cpp
@@ -22,17 +22,17 @@ types::EntityID ECS::preRegisterEntity()
     return entityId;
 }
 
-void ECS::registerSystem(std::unique_ptr<systems::ISystem>&& system)
+void ECS::registerSystem(const std::shared_ptr<systems::ISystem>& system)
 {
     LOG_TRACE_R2("Registered system \"{}\"", system->getName().data());
-    _systems.push_back(std::move(system));
+    _systems.push_back(system);
 }
 
 void ECS::registerSystem(const std::function<void(ECS& ecs)>& applyFn,
                          const std::string& name = "UnknowSystem")
 {
     LOG_TRACE_R2("Registered lambda system \"{}\"", name.data());
-    registerSystem(std::make_unique<systems::SystemWrapper>(applyFn, name));
+    registerSystem(std::make_shared<systems::SystemWrapper>(applyFn, name));
 }
 
 const bitset::DynamicBitSet& ECS::getEntityMask(const types::EntityID entityId) const
@@ -67,7 +67,7 @@ void ECS::destroyEntity(const types::EntityID entityId)
 
 void ECS::applyAllSystems()
 {
-    for (auto&& system : _systems) {
+    for (const auto& system : _systems) {
         system->apply(*this);
     }
 }


### PR DESCRIPTION
# fix(lib/rtecs/systems): Changed systems from unique_ptr to shared_ptr

## Summary
Changed unique_ptr to shared_ptr on systems

## Changes
Changed unique_ptr to shared_ptr on systems

## Breaking changes
- [x] This code contains breaking changes:
```c++
// Systems need to be registered using make_shared<...>(...) and not make_unique<...>(...)
ECS ecs;

// OK
ecs.regsiterSystem(std::make_shared<YourSystem>());
//                                  ^^^^^^^^^^^^^^

// KO
ecs.regsiterSystem(std::make_unique<YourSystem>());
//                                  ^^^^^^^^^^^^^^
```

## Checklist
- [x] I have renamed the first header of the template -_-
- [x] I have tested my modifications
- [x] I have done the relevant documentation
- [x] I have set the Reviewers & Assignees
- [x] I have set the correct `Labels`
- [x] I have set the `rtype` project
- [x] I have set `Status` / `Priority` / `Size` / `Start date` / `End date`
- [x] I have set the relevant `Milestone`
