### PR TITLE
fix(server/packets/wolrd-init): Pushed back the id in the worldInitPa…

### DIFF
--- a/Server/src/lobby/lobby.cpp
+++ b/Server/src/lobby/lobby.cpp
@@ -88,6 +88,7 @@ void Lobby::join(const packet::server::SessionPtr& session)
                     _engine.getEntityInfos(components::GameComponents{}, entity);
                 w.bitsets.push_back(bitset);
                 w.entities.push_back(content);
+                w.ids.push_back(id);
             }
             broadcast(w);
         }


### PR DESCRIPTION
# fix(server/packet/world-init): Fixed segfault of client when receiving the packet WorldInit

## Summary
Fixed a segfault by pushing back the id in the packet.ids vector when the server sends the packet.

## Changes
Pushed back the id when sending the packet WorldInit from the server.

## Breaking changes
- [ ] This code contains breaking changes:

## Screenshots/Video
<img width="735" height="282" alt="image" src="https://github.com/user-attachments/assets/ea30a217-7fa4-44fc-b38d-819b0b35ee6d" />

## Checklist
- [x] I have renamed the first header of the template -_-
- [x] I have tested my modifications
- [x] I have done the relevant documentation
- [x] I have set the Reviewers & Assignees
- [x] I have set the correct `Labels`
- [x] I have set the `rtype` project
- [x] I have set `Status` / `Priority` / `Size` / `Start date` / `End date`
- [x] I have set the relevant `Milestone`
